### PR TITLE
Reimplemented post adapter addItem to use notifyItemInserted and notifyItemChanged instead of notifyDataSetChanged

### DIFF
--- a/app/src/main/java/com/hitherejoe/mvvm_hackernews/view/adapter/PostAdapter.java
+++ b/app/src/main/java/com/hitherejoe/mvvm_hackernews/view/adapter/PostAdapter.java
@@ -51,8 +51,13 @@ public class PostAdapter extends RecyclerView.Adapter<PostAdapter.BindingHolder>
     }
 
     public void addItem(Post post) {
-        mPosts.add(post);
-        notifyDataSetChanged();
+        if (!mPosts.contains(post)) {
+            mPosts.add(post);
+            notifyItemInserted(mPosts.size()-1);
+        } else {
+            mPosts.set(mPosts.indexOf(post), post);
+            notifyItemChanged(mPosts.indexOf(post));
+        }
     }
 
     public static class BindingHolder extends RecyclerView.ViewHolder {


### PR DESCRIPTION
As you can read in the [documentation](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#notifyDataSetChanged%28%29) NotifyDataSetChanged 

> RecyclerView will attempt to synthesize visible structural change events for adapters that report that they have stable IDs when this method is used. This can help for the purposes of animation and visual object persistence but individual item views will still need to be rebound and relaid out.
> 
> If you are writing an adapter it will always be more efficient to use the more specific change events if you can. Rely on notifyDataSetChanged() as a last resort.

I implemented [NotifyItemInserted](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#notifyItemInserted%28int%29) for when a new item is added and [NotifyItemChanged](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#notifyItemChanged%28int,%20java.lang.Object%29) for when an item is updated (that's not happening right now but could in the future).
